### PR TITLE
fastutil dependency 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- fastutil API -->
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Vault API -->
         <dependency>
             <groupId>com.github.MilkBowl</groupId>


### PR DESCRIPTION
CUTTINGEDGE-4.7.4 부터 게임 관련 변수들이 모두 java util에서 fastutil로 변경되었습니다.
라이브러리로 사용 중인 플러그인도 업데이트 해주셔야 합니다.